### PR TITLE
Add a grid property

### DIFF
--- a/src/landlab_bmi/_landlab.py
+++ b/src/landlab_bmi/_landlab.py
@@ -186,6 +186,12 @@ class BmiGridManager(GridManager):
 
     @property
     def grid(self) -> ModelGrid | MappingProxyType[int | None, ModelGrid]:
+        """Get the model's grid or grids.
+
+        If only one grid exists, or multiple grids can be combined into one grid,
+        return it directly; otherwise, return an immutable mapping of grid ids to
+        grids.
+        """
         grids = self._grids.copy()
 
         scalar_grid = grids.pop(None, None)


### PR DESCRIPTION
I've added a `grid` property to the `BmiGridManager` class. If there is only a single grid, that grid is returned. If there is a scalar grid and only one more "regular" grid, the grids are combined and the combined grid is returned. Otherwise, a read-only mapping of all the grids is returned.

I acknowledge that this is confusing but, in practice, this will almost always return a single grid.