### PR TITLE
Ensure BMI var array is added as an array of at least 1 dim

### DIFF
--- a/src/landlab_bmi/_landlab.py
+++ b/src/landlab_bmi/_landlab.py
@@ -176,7 +176,7 @@ class BmiGridManager(GridManager):
         for var in (bmi.var[name] for name in bmi.output_var_names):
             grids[var.grid].add_field(
                 var.name,
-                np.squeeze(var.get()),
+                np.atleast_1d(var.get()),
                 at=LANDLAB_LOCATION[var.location],
                 units=var.units,
             )


### PR DESCRIPTION
When adding BMI var arrays to *Landlab* grids as fields, they should be added as arrays that have at least one dimension. *Landlab*'s `add_field` method raises an error when trying to add a scalar as a new field (unless it's an `at_grid` field).