### PR TITLE
Remove unused names parameter from update method

### DIFF
--- a/src/landlab_bmi/_landlab.py
+++ b/src/landlab_bmi/_landlab.py
@@ -264,7 +264,7 @@ class BmiGridManager(GridManager):
                 units=var.units,
             )
 
-    def update(self, names: Iterable[str] = ()) -> None:
+    def update(self) -> None:
         """Advance the BMI model one step."""
         self._update_bmi_values(self._bmi.input_var_names)
 


### PR DESCRIPTION
The `update` method of `BmiGridManager` had an unused parameter, `names—all of the input/output parameters were being updated, which seems appropriate.