### PR TITLE
remove mypy numpy plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ profile = "black"
 force_single_line = true
 
 [tool.mypy]
-plugins = "numpy.typing.mypy_plugin"
 check_untyped_defs = true
 disallow_any_generics = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
We were getting the following warning,
```
DeprecationWarning: `numpy.typing.mypy_plugin` is deprecated, and will be removed in a future release. Please remove `plugins = numpy.typing.mypy_plugin` in your mypy config.(deprecated in NumPy 2.3)
  sys.exit(console_entry())
```
so I've removed the indicated line from our *pyproject.toml* file.