### PR TITLE
Change advance method to return the new time

### DIFF
--- a/src/landlab_bmi/_time_stepper.py
+++ b/src/landlab_bmi/_time_stepper.py
@@ -103,7 +103,7 @@ class TimeStepper:
         """Time units."""
         return self._units
 
-    def advance(self) -> None:
+    def advance(self) -> float:
         """Advance the time by one step.
 
         Increments the internal time by `step`. If the current time is already
@@ -111,6 +111,11 @@ class TimeStepper:
         `EndOfTime` exception is raised. The final value of `time` may equal or
         exceed `stop`, but no further advances are permitted once this condition
         is reached.
+
+        Returns
+        -------
+        float
+            The updated time after advancing.
 
         Raises
         ------
@@ -123,6 +128,7 @@ class TimeStepper:
                 f"(stop time is {self._stop})"
             )
         self._time += self._step
+        return self._time
 
 
 def _never_stop(now: float) -> bool:

--- a/src/landlab_bmi/_time_stepper.py
+++ b/src/landlab_bmi/_time_stepper.py
@@ -34,11 +34,11 @@ class TimeStepper:
     1.0
     >>> time_stepper.time
     0.0
-    >>> for _ in range(10):
-    ...     time_stepper.advance()
-    ...
+    >>> times = [time_stepper.advance() for _ in range(10)]
     >>> time_stepper.time
     10.0
+    >>> times
+    [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
     >>> time_stepper = TimeStepper(1.0, 13.0, 2.0)
     >>> [time for time in time_stepper]
     [3.0, 5.0, 7.0, 9.0, 11.0, 13.0]


### PR DESCRIPTION
As the title says, I've changed the `advance` method to return the new time. This, among other things, makes it easier to create an array of times,
```python
times = [time_stepper.advance() for _ in range(10)]
```
Maybe confusingly (?), `advance` both modifies the internals of the time stepper and returns a value. This, however, follows the pattern of other methods like the `pop` method of a `dict`, so I figured it was ok.